### PR TITLE
feat(value): add NewDateYMD constructor

### DIFF
--- a/value/date.go
+++ b/value/date.go
@@ -75,6 +75,13 @@ func NewDate(tm time.Time) DateJp {
 	return DateJp{time.Unix(((ut+int64(offset))/86400)*86400-jstoffset, 0).In(JST)}
 }
 
+// NewDateYMD returns DateJp from explicit year/month/day values.
+//
+// The generated value is interpreted in JST and normalized by NewDate.
+func NewDateYMD(year int, month time.Month, day int) DateJp {
+	return NewDate(time.Date(year, month, day, 0, 0, 0, 0, JST))
+}
+
 var timeTemplate = []string{
 	"2006-01-02",
 	"2006-01",

--- a/value/date_test.go
+++ b/value/date_test.go
@@ -92,6 +92,29 @@ func TestDateJp(t *testing.T) {
 	}
 }
 
+func TestNewDateYMD(t *testing.T) {
+	testCases := []struct {
+		year  int
+		month time.Month
+		day   int
+		want  string
+	}{
+		{year: 2024, month: time.June, day: 1, want: "2024-06-01"},
+		{year: 2024, month: time.December, day: 31, want: "2024-12-31"},
+		{year: 2019, month: time.May, day: 1, want: "2019-05-01"},
+	}
+
+	for _, tc := range testCases {
+		dt := NewDateYMD(tc.year, tc.month, tc.day)
+		if got := dt.String(); got != tc.want {
+			t.Errorf("value.NewDateYMD(%d, %v, %d) is %q, want %q", tc.year, tc.month, tc.day, got, tc.want)
+		}
+		if _, offset := dt.Zone(); offset != int((9 * time.Hour).Seconds()) {
+			t.Errorf("value.NewDateYMD(%d, %v, %d) zone offset is %d, want %d", tc.year, tc.month, tc.day, offset, int((9 * time.Hour).Seconds()))
+		}
+	}
+}
+
 type ForTestStruct struct {
 	DateTaken DateJp `json:"date_taken,omitempty"`
 }


### PR DESCRIPTION
## Summary
- add NewDateYMD(year int, month time.Month, day int) DateJp to create DateJp from explicit Y/M/D values
- keep behavior aligned with existing DateJp normalization by routing through NewDate
- add unit tests for date value and JST zone offset

## Validation
- go test ./...

## Notes
- month argument type is time.Month by design.