### PR TITLE
feat(value): add IterDay iterator and usage sample

### DIFF
--- a/README.md
+++ b/README.md
@@ -342,6 +342,46 @@ $ go run sample/sample4.go 2023-02-25
 Julian Day Number of 2023-02-25 is 2460000
 ```
 
+### 日付を5日分イテレートする
+
+```go
+package main
+
+import (
+    "fmt"
+    "os"
+    "time"
+
+    "github.com/goark/koyomi/value"
+)
+
+func main() {
+    start := value.NewDateYMD(2024, time.June, 1)
+    until := start.AddDay(4)
+
+    seq, err := start.IterDay(1, until)
+    if err != nil {
+        fmt.Fprintln(os.Stderr, err)
+        return
+    }
+
+    for d := range seq {
+        fmt.Println(d.String())
+    }
+}
+```
+
+これを実行すると以下のような結果になります。
+
+```
+$ go run sample/sample5.go
+2024-06-01
+2024-06-02
+2024-06-03
+2024-06-04
+2024-06-05
+```
+
 ## Modules Requirement Graph
 
 [![dependency.png](./dependency.png)](./dependency.png)

--- a/sample/sample5.go
+++ b/sample/sample5.go
@@ -1,0 +1,27 @@
+//go:build ignore
+// +build ignore
+
+package main
+
+import (
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/goark/koyomi/value"
+)
+
+func main() {
+	start := value.NewDateYMD(2024, time.June, 1)
+	until := start.AddDay(4)
+
+	seq, err := start.IterDay(1, until)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		return
+	}
+
+	for d := range seq {
+		fmt.Println(d.String())
+	}
+}

--- a/value/date.go
+++ b/value/date.go
@@ -1,6 +1,7 @@
 package value
 
 import (
+	"iter"
 	"strconv"
 	"strings"
 	"time"
@@ -174,6 +175,39 @@ func (t DateJp) AddDate(years int, months int, days int) DateJp {
 // AddDay method adds n days and returns new Date instance.
 func (t DateJp) AddDay(days int) DateJp {
 	return t.AddDate(0, 0, days)
+}
+
+// IterDay returns an iterator that yields DateJp values from t to until.
+//
+// The iterator yields both endpoints and advances by AddDay(count) on each step.
+// A non-zero count is required. If count and until cannot reach each other
+// (direction mismatch or non-divisible distance), IterDay returns an error.
+func (t DateJp) IterDay(count int, until DateJp) (iter.Seq[DateJp], error) {
+	if count == 0 {
+		return nil, errs.Wrap(ErrInvalidCount, errs.WithContext("count", count), errs.WithContext("start", t.String()), errs.WithContext("until", until.String()))
+	}
+
+	diff := int(until.Sub(t.Time).Hours() / 24)
+	if (count > 0 && diff < 0) || (count < 0 && diff > 0) {
+		return nil, errs.Wrap(ErrInfiniteLoop, errs.WithContext("count", count), errs.WithContext("start", t.String()), errs.WithContext("until", until.String()))
+	}
+
+	absCount := count
+	if absCount < 0 {
+		absCount = -absCount
+	}
+	if diff%absCount != 0 {
+		return nil, errs.Wrap(ErrInfiniteLoop, errs.WithContext("count", count), errs.WithContext("start", t.String()), errs.WithContext("until", until.String()))
+	}
+
+	steps := diff / count
+	return func(yield func(DateJp) bool) {
+		for i := 0; i <= steps; i++ {
+			if !yield(t.AddDay(i * count)) {
+				return
+			}
+		}
+	}, nil
 }
 
 // WeekdayJp returns the Japanese representation of the weekday for the given DateJp.

--- a/value/date_test.go
+++ b/value/date_test.go
@@ -2,6 +2,7 @@ package value
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"testing"
 	"time"
@@ -183,6 +184,97 @@ func TestEqual(t *testing.T) {
 	}
 	if !dt1.AddDay(1).Equal(dt2) {
 		t.Error("DateJp.Equal() is false, want true.")
+	}
+}
+
+func TestIterDayForward(t *testing.T) {
+	start := NewDateYMD(2024, time.June, 1)
+	until := NewDateYMD(2024, time.June, 3)
+
+	seq, err := start.IterDay(1, until)
+	if err != nil {
+		t.Errorf("DateJp.IterDay() is %v, want nil.", err)
+		return
+	}
+
+	want := []string{"2024-06-01", "2024-06-02", "2024-06-03"}
+	idx := 0
+	for dt := range seq {
+		if idx >= len(want) {
+			t.Errorf("DateJp.IterDay() yielded too many values, got at least %d", idx+1)
+			return
+		}
+		if got := dt.String(); got != want[idx] {
+			t.Errorf("DateJp.IterDay()[%d] is %q, want %q", idx, got, want[idx])
+		}
+		idx++
+	}
+	if idx != len(want) {
+		t.Errorf("DateJp.IterDay() yielded %d values, want %d", idx, len(want))
+	}
+}
+
+func TestIterDayBackward(t *testing.T) {
+	start := NewDateYMD(2024, time.June, 3)
+	until := NewDateYMD(2024, time.June, 1)
+
+	seq, err := start.IterDay(-1, until)
+	if err != nil {
+		t.Errorf("DateJp.IterDay() is %v, want nil.", err)
+		return
+	}
+
+	want := []string{"2024-06-03", "2024-06-02", "2024-06-01"}
+	idx := 0
+	for dt := range seq {
+		if idx >= len(want) {
+			t.Errorf("DateJp.IterDay() yielded too many values, got at least %d", idx+1)
+			return
+		}
+		if got := dt.String(); got != want[idx] {
+			t.Errorf("DateJp.IterDay()[%d] is %q, want %q", idx, got, want[idx])
+		}
+		idx++
+	}
+	if idx != len(want) {
+		t.Errorf("DateJp.IterDay() yielded %d values, want %d", idx, len(want))
+	}
+}
+
+func TestIterDayErrInvalidCount(t *testing.T) {
+	start := NewDateYMD(2024, time.June, 1)
+	until := NewDateYMD(2024, time.June, 3)
+
+	_, err := start.IterDay(0, until)
+	if err == nil {
+		t.Error("DateJp.IterDay() error = nil, not want nil.")
+		return
+	}
+	if !errors.Is(err, ErrInvalidCount) {
+		t.Errorf("DateJp.IterDay() error = %v, want errors.Is(..., ErrInvalidCount) true.", err)
+	}
+}
+
+func TestIterDayErrInfiniteLoop(t *testing.T) {
+	testCases := []struct {
+		name  string
+		start DateJp
+		count int
+		until DateJp
+	}{
+		{name: "direction mismatch", start: NewDateYMD(2024, time.June, 3), count: 1, until: NewDateYMD(2024, time.June, 1)},
+		{name: "step never reaches until", start: NewDateYMD(2024, time.June, 1), count: 2, until: NewDateYMD(2024, time.June, 4)},
+	}
+
+	for _, tc := range testCases {
+		_, err := tc.start.IterDay(tc.count, tc.until)
+		if err == nil {
+			t.Errorf("DateJp.IterDay(%s) error = nil, not want nil.", tc.name)
+			continue
+		}
+		if !errors.Is(err, ErrInfiniteLoop) {
+			t.Errorf("DateJp.IterDay(%s) error = %v, want errors.Is(..., ErrInfiniteLoop) true.", tc.name, err)
+		}
 	}
 }
 

--- a/value/ecode.go
+++ b/value/ecode.go
@@ -1,0 +1,23 @@
+package value
+
+import "errors"
+
+var (
+	ErrInvalidCount = errors.New("invalid count")
+	ErrInfiniteLoop = errors.New("infinite loop")
+)
+
+/* Copyright 2020-2026 Spiegel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * 	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */


### PR DESCRIPTION
## Summary
- add DateJp.IterDay(count int, until DateJp) returning iter.Seq[DateJp]
- add validation errors ErrInvalidCount and ErrInfiniteLoop in value package
- return wrapped errors with context for invalid count and infinite-loop conditions
- add unit tests for forward, backward, invalid count, and infinite-loop cases
- add IterDay example to README and add sample/sample5.go

## Validation
- go run sample/sample5.go
- go test ./...